### PR TITLE
Fix: Removed bool typecast from $ReadOnlyID to prevent incorrect Etherpad ID (1)

### DIFF
--- a/classes/class.ilObjEtherpadLite.php
+++ b/classes/class.ilObjEtherpadLite.php
@@ -32,7 +32,7 @@
 class ilObjEtherpadLite extends ilObjectPlugin
 {
     private ilEtherpadLiteConfig $adminSettings;
-    private bool $ReadOnlyID;
+    private $ReadOnlyID;
     private bool $ReadOnly;
     private string $EtherpadText;
     private bool $oldEtherpad;


### PR DESCRIPTION


Typecasting $ReadOnlyID to bool caused any non-empty ID to become `true`, which was cast to integer `1`. This led to the iframe always referencing Etherpad ID 1, which does not exist. Removing the type declaration fixes the issue by preserving the correct ID.